### PR TITLE
Fix ipinfo

### DIFF
--- a/bucket/ipinfo.json
+++ b/bucket/ipinfo.json
@@ -19,7 +19,7 @@
    }
   }
  },
- "bin": "ipinfo_2.8.0_windows_amd64.exe",
+ "bin": "ipinfo.exe",
  "checkver": {
   "regex": "ipinfo_([\\d.]+)_windows_386\\.zip",
   "url": "https://github.com/ipinfo/cli/releases"


### PR DESCRIPTION
Current version cause error:
```
> ipinfo
ipinfo: The term 'ipinfo' is not recognized as a name of a cmdlet, function, script file, or executable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```

Relates to #14 
