### PR TITLE
Fix shim for gomi

### DIFF
--- a/bucket/gomi.json
+++ b/bucket/gomi.json
@@ -19,7 +19,7 @@
    }
   }
  },
- "bin": "gomi.exe",
+ "bin": [["gomi_windows_amd64.exe", "gomi"]],
  "checkver": "github",
  "description": "A simple trash tool that works on CLI",
  "homepage": "https://github.com/b4b4r07/gomi",


### PR DESCRIPTION
Fixes this error:
```
PS ~\scoop\buckets\DEV-Tools> scoop install gomi
Installing 'gomi' (0.1.7) [64bit] from DEV-Tools bucket
Loading gomi_windows_amd64.exe from cache.
Checking hash of gomi_windows_amd64.exe ... ok.
Linking ~\scoop\apps\gomi\current => ~\scoop\apps\gomi\0.1.7
Creating shim for 'gomi'.
Can't shim 'gomi.exe': File doesn't exist.
PS ~\scoop\buckets\DEV-Tools>
```