### PR TITLE
New package: wslcompact, reduces the size of the ever growing WSL images

### DIFF
--- a/bucket/wslcompact.json
+++ b/bucket/wslcompact.json
@@ -1,0 +1,20 @@
+{
+    "version": "2.2023.01.29",
+    "description": "Compacts the size of the WSL images by removing unused empty space.",
+    "homepage": "https://github.com/okibcn/wslcompact",
+    "license": "GPL-3.0-only",
+    "notes": [
+        "Type wslcompact -h before using it for the first time to learn how it works.",
+        "Visit https://github.com/okibcn/wslcompact for more information."
+    ],
+    "url": "https://raw.githubusercontent.com/okibcn/wslcompact/main/wslcompact.ps1",
+    "hash": "b49019bc6bc06606e21c0d795f2c097ce73c6f9a58676d6685b2997fdfcf5776",
+    "bin": "wslcompact.ps1",
+    "checkver": {
+        "url": "https://raw.githubusercontent.com/okibcn/wslcompact/main/wslcompact.ps1",
+        "regex": "v([\\d\\.]+)"
+    },
+    "autoupdate": {
+        "url": "https://raw.githubusercontent.com/okibcn/wslcompact/main/wslcompact.ps1"
+    }
+}


### PR DESCRIPTION
`wslcompact` compacts the size of the WSL images by removing unused empty space.

Project homepage: https://github.com/okibcn/wslcompact



- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
