### PR TITLE
New package format for WslCompact requires new manifest, simplified Nano manifest.

### DIFF
--- a/bucket/nano.json
+++ b/bucket/nano.json
@@ -1,38 +1,31 @@
 {
-    "version": "7.2-8-10163.2",
-    "description": "The legendary small and friendly GNU editor, now UTF-8 ready for Windows 32/64",
+    "version": "7.2-10-10165",
+    "description": "The legendary small and friendly GNU editor, UTF-8 and mouse ready for Windows CLI 32/64 bits",
     "homepage": "https://www.nano-editor.org/",
     "license": "GPL-3.0-only",
-    "notes": "Configure nano by editing its configuration file with nano ~/.nanorc",
-    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-8-10163.2/nano-for-windows_v7.2-8-10163.2.7z",
-    "hash": "c7b4c832c8dac06ba4bfa1619c31faf89db790462acaffa6cef8d14f2cbc31c1",
+    "notes": [
+        "Configure nano interface, colors, key assignments and more by typing nano ~/.nanorc",
+        "Default folders have been updated, no custom setting has been modified. Find a backup of",
+        "the old config file at \"$dir\\.nanorc.bak\"",
+        "Visit https://github.com/okibcn/nano-for-windows for more information."
+    ],
+    "url": "https://github.com/okibcn/nano-for-windows/releases/download/v7.2-10-10165/nano-for-windows_v7.2-10-10165.7z",
+    "hash": "04778fc33c2dac15434245807a226fe312480b550f6d1759f2799aa2f84ef3cd",
     "bin": "nano.exe",
-    "architecture": {
-        "64bit": {
-            "pre_install": [
-                "if (-not (Test-Path ~/.nanorc)) {",
-                "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
-                "    Add-Content ~/.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
-                "Move-Item \"$dir/pkg_x86_64-w64-mingw32/bin/*\" \"$dir\"",
-                "Move-Item \"$dir/pkg_x86_64-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
-                "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
-                "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc",
-                "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', '~/scoop/apps/nano/current/syntax' | Set-Content ~/.nanorc"
-            ]
-        },
-        "32bit": {
-            "pre_install": [
-                "if (-not (Test-Path ~/.nanorc)) {",
-                "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
-                "    Add-Content ~/.nanorc 'include \"~/scoop/apps/nano/current/syntax/*.nanorc\"'}",
-                "Move-Item \"$dir/pkg_i686-w64-mingw32/bin/*\" \"$dir\"",
-                "Move-Item \"$dir/pkg_i686-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
-                "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
-                "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc",
-                "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', '~/scoop/apps/nano/current/syntax' | Set-Content ~/.nanorc"
-            ]
-        }
-    },
+    "pre_install": [
+        "$arch=if ($architecture -match '64') {'x86_64'} else {'i686'}",
+        "$scoopdir=$scoopdir -replace '\\\\','/'",
+        "if (-not (Test-Path ~/.nanorc)){",
+        "    Move-Item \"$dir/.nanorc\" ~/.nanorc",
+        "    Add-Content ~/.nanorc \"include `\"$scoopdir/apps/nano/current/syntax/*.nanorc`\"\"}",
+        "else{Copy-Item ~/.nanorc \"$dir/.nanorc.bak\"}",
+        "Move-Item \"$dir/pkg_$arch-w64-mingw32/bin/*\" \"$dir\"",
+        "Move-Item \"$dir/pkg_$arch-w64-mingw32/share/nano\" \"$dir/syntax\" -Force",
+        "Remove-Item  \"$dir/pkg*\" -Force -Recurse",
+        "(Get-Content ~/.nanorc) -replace '(@PKGDATADIR@)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc",
+        "(Get-Content ~/.nanorc) -replace '(/usr/share/nano)', \"$scoopdir/apps/nano/current/syntax\" | Set-Content ~/.nanorc",
+        "(Get-Content ~/.nanorc) -replace '(pkg_.*-w64-mingw32.share.nano)', 'syntax' | Set-Content ~/.nanorc"
+    ],
     "checkver": {
         "github": "https://api.github.com/repos/okibcn/nano-for-windows",
         "regex": "v([\\d\\.\\-]+)\\.7z"

--- a/bucket/wslcompact.json
+++ b/bucket/wslcompact.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.0",
+    "version": "6.0",
     "description": "Safely compacts the size of the ever-growing WSL vhdx images.",
     "homepage": "https://github.com/okibcn/wslcompact",
     "license": "GPL-3.0-only",
@@ -7,8 +7,8 @@
         "Type wslcompact -h before using it for the first time to learn how it works.",
         "Visit https://github.com/okibcn/wslcompact for more information."
     ],
-    "url": "https://github.com/okibcn/wslcompact/releases/download/5.0/WslCompact-v5.0.zip",
-    "hash": "9d320271c3f01131561efaee1ba1fba70c98521d5887857e10548e1b15c07f32",
+    "url": "https://github.com/okibcn/wslcompact/releases/download/6.0/WslCompact-v6.0.zip",
+    "hash": "d5746c149fa2a64456e7b10a04f6cdd42a10b6eeb3e2e96d0eb6ee131bdae54c",
     "bin": "wslcompact.ps1",
     "pre_install": [
         "(get-content \"$dir/wslcompact/WslCompact.psm1\") -replace '^Export.*', 'WslCompact @args' | Set-Content \"$dir/wslcompact.ps1\"",

--- a/bucket/wslcompact.json
+++ b/bucket/wslcompact.json
@@ -1,20 +1,24 @@
 {
-    "version": "4.2023.01.31",
-    "description": "Compacts the size of the WSL images by removing unused empty space.",
+    "version": "5.0",
+    "description": "Safely compacts the size of the ever-growing WSL vhdx images.",
     "homepage": "https://github.com/okibcn/wslcompact",
     "license": "GPL-3.0-only",
     "notes": [
         "Type wslcompact -h before using it for the first time to learn how it works.",
         "Visit https://github.com/okibcn/wslcompact for more information."
     ],
-    "url": "https://raw.githubusercontent.com/okibcn/wslcompact/main/wslcompact.ps1",
-    "hash": "d34223c4748171e64c3d5164aa76a8c9e8b3eb413f801fe3e7db35c3da43703e",
+    "url": "https://github.com/okibcn/wslcompact/releases/download/5.0/WslCompact-v5.0.zip",
+    "hash": "9d320271c3f01131561efaee1ba1fba70c98521d5887857e10548e1b15c07f32",
     "bin": "wslcompact.ps1",
+    "pre_install": [
+        "(get-content \"$dir/wslcompact/WslCompact.psm1\") -replace '^Export.*', 'WslCompact @args' | Set-Content \"$dir/wslcompact.ps1\"",
+        "Remove-Item \"$dir/wslcompact\" -Recurse -Force"
+    ],
     "checkver": {
-        "url": "https://raw.githubusercontent.com/okibcn/wslcompact/main/wslcompact.ps1",
-        "regex": "v([\\d\\.]+)"
+        "github": "https://api.github.com/repos/okibcn/wslcompact",
+        "regex": "v([\\d\\.\\-]+)\\.zip"
     },
     "autoupdate": {
-        "url": "https://raw.githubusercontent.com/okibcn/wslcompact/main/wslcompact.ps1"
+        "url": "https://github.com/okibcn/wslcompact/releases/download/$version/WslCompact-v$version.zip"
     }
 }


### PR DESCRIPTION
- WslCompact: is now delivered as a zip file. Manifest Update to install it properly. New version.
- Nano now has a simplified installer. New version.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
