### PR TITLE
wkhtmltopdf : Add version 0.12.5-1

### DIFF
--- a/bucket/wkhtmltopdf.0.12.5-1.json
+++ b/bucket/wkhtmltopdf.0.12.5-1.json
@@ -1,0 +1,21 @@
+{
+    "homepage": "https://wkhtmltopdf.org/",
+    "version": "0.12.5-1",
+    "description": "Render HTML into PDF",
+    "license": "LGPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox-0.12.5-1.mxe-cross-win64.7z",
+            "hash": "d9c4717318439f7576ce201de145f0b71ffdd209faadec8dcfb1be088eae6e71"
+        },
+        "32bit": {
+            "url": "https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox-0.12.5-1.mxe-cross-win32.7z",
+            "hash": "eb00f88ceed2941430cb05bc91da4e753e2319188b8e891735ad141aad668ae8"
+        }
+    },
+    "extract_dir": "wkhtmltox/bin",
+    "bin": [
+        "wkhtmltoimage.exe",
+        "wkhtmltopdf.exe"
+    ]
+}


### PR DESCRIPTION
[wkhtmltopdf](https://wkhtmltopdf.org/) and wkhtmltoimage are open source (LGPLv3) command line tools to render HTML into PDF and various image formats using the Qt WebKit rendering engine. These run entirely "headless" and do not require a display or display service.

_There is already an App Manifest for [wkhtmltopdf](https://wkhtmltopdf.org/), See [here](https://github.com/ScoopInstaller/Main/blob/master/bucket/wkhtmltopdf.json). But, it use the [wkhtmltopdf/packaging](https://github.com/wkhtmltopdf/packaging) repository which only contains releases for 0.12.6. The older releases are in [wkhtmltopdf/wkhtmltopdf](https://github.com/wkhtmltopdf/wkhtmltopdf) repository & currently it is in archived state._

**The requirement of [wkhtmltopdf](https://wkhtmltopdf.org/) 0.12.5 is that : [Odoo 16](https://www.odoo.com/) needs 0.12.5 version of [wkhtmltopdf](https://wkhtmltopdf.org/) as dependency in windows, See https://www.odoo.com/documentation/16.0/administration/install/install.html#setup-install-source.**

[Odoo](https://www.odoo.com/) is a suite of [business management software](https://en.wikipedia.org/wiki/Business_management_tools) tools including, for example, [CRM](https://en.wikipedia.org/wiki/Customer_relationship_management), e-commerce, billing, accounting, manufacturing, warehouse, project management, and inventory management.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).