### PR TITLE
mingw-ucrt : Add version 12.2.0-rt_v10-rev2

### DIFF
--- a/bucket/mingw-ucrt.json
+++ b/bucket/mingw-ucrt.json
@@ -1,0 +1,35 @@
+{
+    "version": "12.2.0-rt_v10-rev2",
+    "description": "Minimalistic GNU for Windows is a runtime environment for GCC, GDB, make and related binutils. (UCRT build)",
+    "homepage": "https://www.mingw-w64.org",
+    "license": "ZPL-2.1",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/x86_64-12.2.0-release-posix-seh-ucrt-rt_v10-rev2.7z",
+            "hash": "dc1f299e8450c96f59f4b8f7c1290ebb78ee00ddb71f9ed4ca0efaf5462f8c4e",
+            "extract_dir": "mingw64"
+        },
+        "32bit": {
+            "url": "https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/i686-12.2.0-release-posix-dwarf-ucrt-rt_v10-rev2.7z",
+            "hash": "b0740ad416aceabac00446730038677963c5ad8e4ba52b14d11941daca9e99e9",
+            "extract_dir": "mingw32"
+        }
+    },
+    "post_install": "Copy-Item \"$dir\\bin\\mingw32-make.exe\" \"$dir\\bin\\make.exe\"",
+    "env_add_path": "bin",
+    "checkver": {
+        "url": "https://github.com/niXman/mingw-builds-binaries/releases",
+        "regex": "Release of ([\\d.]+)-(?<build>[a-z0-9_\\-]+)",
+        "replace": "${1}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/niXman/mingw-builds-binaries/releases/download/$version/x86_64-$match1-release-posix-seh-ucrt-$matchBuild.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/niXman/mingw-builds-binaries/releases/download/$version/i686-$match1-release-posix-dwarf-ucrt-$matchBuild.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
From version [12.2.0-rt_v10-rev2](https://github.com/niXman/mingw-builds-binaries/releases/tag/12.2.0-rt_v10-rev2) [UCRT](https://learn.microsoft.com/en-us/cpp/windows/universal-crt-deployment?view=msvc-170) builds are available for [Mingw-w64](https://www.mingw-w64.org/) via. [niXman/mingw-builds-binaries](https://github.com/niXman/mingw-builds-binaries) repository.

For MSVCRT vs UCRT things, see https://www.msys2.org/docs/environments.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).