### PR TITLE
wub_arch3rPro@1.8: Appended a URL fragment(#/)

### DIFF
--- a/bucket/wub_arch3rPro.json
+++ b/bucket/wub_arch3rPro.json
@@ -3,7 +3,7 @@
     "description": "wub 彻底关闭Win10自动更新工具(Windows Update Blocker) ",
     "homepage": "https://www.sordum.org/downloads/?st-windows-update-blocker",
     "license": "Freeware",
-    "url": "https://www.sordum.org/files/downloads.php?st-windows-update-blocker.zip",
+    "url": "https://www.sordum.org/files/downloads.php?st-windows-update-blocker#/wub.zip",
     "hash": "C9276A36930AA9E3D58B5851973B67FFE8A7C2828774198E3986DF0574CEF0BF",
     "extract_dir": "Wub",
     "architecture": {
@@ -30,6 +30,6 @@
         "regex": "title=\"Windows Update Blocker v([\\d.]+)\""
     },
     "autoupdate": {
-        "url": "https://www.sordum.org/files/downloads.php?st-windows-update-blocker.zip"
+        "url": "https://www.sordum.org/files/downloads.php?st-windows-update-blocker#/wub.zip"
     }
 }


### PR DESCRIPTION
Appended a URL fragment(#/) to change extension of downloaded file from php to zip.
Otherwise, a file with php extension will be downloaded and decompression will fail.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
