### PR TITLE
ultraiso_ScoopInstaller@9.7.6.3860: Append a URL fragment(#/)

### DIFF
--- a/bucket/ultraiso_ScoopInstaller.json
+++ b/bucket/ultraiso_ScoopInstaller.json
@@ -6,7 +6,7 @@
     "identifier": "Proprietary",
     "url": "https://www.ezbsystems.com/pad/ultraiso.xml"
   },
-  "url": "http://www.ezbsystems.com/dl1.php?file=uiso9_pe.exe",
+  "url": "http://www.ezbsystems.com/dl1.php?file=uiso9_pe.exe#/setup.exe",
   "hash": "5564abf832bcb92cefe7209cb8a583c462dbf8ab3652697634cd178324352616",
   "innosetup": true,
   "bin": "UltraISO.exe",
@@ -21,6 +21,6 @@
     "regex": "<font size=\"2\">([\\d.]+)</font>"
   },
   "autoupdate": {
-    "url": "http://www.ezbsystems.com/dl1.php?file=uiso$majorVersion_pe.exe"
+    "url": "http://www.ezbsystems.com/dl1.php?file=uiso$majorVersion_pe.exe#/setup.exe"
   }
 }


### PR DESCRIPTION
Please append a URL fragment(#/) to change extension of downloaded file from php to exe.
Otherwise, a file with php extension will be downloaded and installation will fail.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
