### PR TITLE
Update pureref@2.0.3

### DIFF
--- a/bucket/pureref.json
+++ b/bucket/pureref.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.11.1",
+    "version": "2.0.3",
     "description": "Simple and lightweight tool for artists to organize and view reference images",
     "homepage": "https://www.pureref.com/",
     "license": {
@@ -11,14 +11,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/pureref/PureRef-1.11.1_x64.zip",
-            "hash": "ea2fa5b34a2beea883f1cf81e16f91bc7970f5ce98b55b9d9990810f096d69fb",
-            "extract_dir": "PureRef-1.11.1_x64"
-        },
-        "32bit": {
-            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/pureref/PureRef-1.11.1_x86.zip",
-            "hash": "ac32eb97d2be9e436dc777c7d8b5bbc5524fdd29c9e5e5e8255678b06b92e10e",
-            "extract_dir": "PureRef-1.11.1_x86"
+            "url": "https://download.filepuma.com/files/photos-and-images/pureref-64bit-/PureRef_(64bit)_v2.0.3.exe#/pureref.zip",
+            "hash":"05a5f7b10894697ab4a54658fa70c30880e061fce7205dd41073d5315def1d0f"
         }
     },
     "bin": "PureRef.exe",
@@ -27,9 +21,5 @@
             "PureRef.exe",
             "PureRef"
         ]
-    ],
-    "checkver": {
-        "url": "https://www.pureref.com/changelog.php",
-        "regex": "<h2>Version ([\\d.]+)"
-    }
+    ]
 }


### PR DESCRIPTION
Update to the latest version. The software's official website no longer provides direct download links, so alternative website links are being used instead.