### PR TITLE
Fix download URL in adbfilemanager.json

### DIFF
--- a/bucket/adbfilemanager.json
+++ b/bucket/adbfilemanager.json
@@ -5,8 +5,8 @@
     "license": "Unknown",
     "architecture": {
         "64bit": {
-            "url": "https://ghproxy.com/https://github.com/T0biasCZe/AdbFileManager/releases/download/v1.9/afm.zip",
-            "hash": "1bf09a1fff643c5741af21f8160b2e70caad62d0584ed2b271b49bd3c2efd57f"
+            "url": "https://ghproxy.com/https://github.com/T0biasCZe/AdbFileManager/releases/download/v1.9/AFM.1.9.zip",
+            "hash": "cd52980a8c766950001c60a1c19193d4eb36e0f0a5f410abde6332484583b6b0"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
