### PR TITLE
lazygit: update to version 0.62.0

### DIFF
--- a/bucket/lazygit.json
+++ b/bucket/lazygit.json
@@ -1,20 +1,20 @@
 {
-    "version": "0.58.1",
+    "version": "0.62.0",
     "description": "A simple terminal UI for git commands",
     "homepage": "https://github.com/jesseduffield/lazygit",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/jesseduffield/lazygit/releases/download/v0.58.1/lazygit_0.58.1_Windows_x86_64.zip",
-            "hash": "81f6f925e7eb97b32f89dd9c3597fed245f26fe81c7162a2470d501051f996dd"
+            "url": "https://github.com/jesseduffield/lazygit/releases/download/v0.62.0/lazygit_0.62.0_windows_x86_64.zip",
+            "hash": "132247de071b238cbcd40b0559de6ac248af7cbb97c1c93ae465537333286f04"
         },
         "32bit": {
-            "url": "https://github.com/jesseduffield/lazygit/releases/download/v0.58.1/lazygit_0.58.1_Windows_32-bit.zip",
-            "hash": "dad6c71c8c77f337de13147927b896d805eed2b63abee2b77a9347a439b39015"
+            "url": "https://github.com/jesseduffield/lazygit/releases/download/v0.62.0/lazygit_0.62.0_windows_32-bit.zip",
+            "hash": "125c6297ccc96475d319d23dc7c0a302416b824af1eda32302a83a33d574ba97  "
         },
         "arm64": {
-            "url": "https://github.com/jesseduffield/lazygit/releases/download/v0.58.1/lazygit_0.58.1_Windows_arm64.zip",
-            "hash": "256bb4840185a2e693cd3058bb79f782144fc227998753f5489d9b99c56dcc3d"
+            "url": "https://github.com/jesseduffield/lazygit/releases/download/v0.62.0/lazygit_0.62.0_windows_arm64.zip",
+            "hash": "6766e044615237318fb0c655a85ea8b69ef09129406adf0985ee1afb183205e9  "
         }
     },
     "bin": "lazygit.exe",


### PR DESCRIPTION

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
